### PR TITLE
Fix Dependabot private-registry resolution (@hillwoodpark scope)

### DIFF
--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+@hillwoodpark:registry=https://npm.pkg.github.com


### PR DESCRIPTION
Dependabot's npm updater now requires that any private npm registry referenced in `dependabot.yml` (via `registries: "*"`) have an explicit scope→registry mapping — either via a `scope`/`replaces-base` field in the registry config, or via a `.npmrc` file. Without this, the updater fails at the file-fetch stage with `private_registry_config_not_found` before any packages are evaluated; this repo has been seeing that failure on every daily run since 2026-06-27.

This PR adds a single-line `.npmrc` at the repo root that maps the `@hillwoodpark` scope to `npm.pkg.github.com`. The file contains no auth token — Dependabot injects credentials from its own `registries` block at runtime; committing a token would be a security leak and is intentionally omitted.

🤖 Generated with [Claude Code](https://claude.com/claude-code)