### PR TITLE
Add 3-day supply-chain cooldown (Dependabot + npm min-release-age)

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -10,6 +10,11 @@ updates:
     registries: "*"
     schedule:
       interval: "daily"
+    # Supply-chain cooldown: hold new releases 3 days (first-party @hillwoodpark exempt)
+    cooldown:
+      default-days: 3
+      exclude:
+        - "@hillwoodpark/*"
 registries:
   npm-github:
     type: npm-registry

--- a/.npmrc
+++ b/.npmrc
@@ -1,1 +1,5 @@
 @hillwoodpark:registry=https://npm.pkg.github.com
+
+# Supply-chain: only install dependency versions >=3 days old (first-party @hillwoodpark exempt)
+min-release-age=3
+min-release-age-exclude[]=@hillwoodpark/*


### PR DESCRIPTION
Adds a **3-day supply-chain cooldown** as defense-in-depth against malicious *new* npm releases (account-takeover publishes, protestware, etc. — typically caught and yanked within days):

- **Dependabot** (`.github/dependabot.yml`): `cooldown.default-days: 3` — version-update PRs wait until a release is ≥ 3 days old. Security (advisory) updates are exempt from cooldown, so CVE fixes still land immediately.
- **npm** (`.npmrc`): `min-release-age=3` — a hard floor at install time, covering manual installs and transitive resolution that Dependabot doesn't see.

First-party `@hillwoodpark/*` packages are excluded from both, so internal releases propagate with no delay. The two windows are equal (3 = 3), so the lockfile never holds a sub-window version and `npm ci` stays clean. No secrets are added.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
